### PR TITLE
Grant 'write' permission to upload-rust-binary-action upon Release registration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: write
+
 on:
   release:
     types: [created, edited]


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR aims to address the insufficient permissions issue in the GitHub Action setup that triggers upon Release registration. By adding the code snippet below, the 'upload-rust-binary-action' will have the necessary 'contents' write permission to allow Content writing post-build.

```yaml
permissions:
  contents: write
```

#### Any background context you want to provide?
The reference repository that is pertinent to this change is [taiki-e/upload-rust-binary-action](https://github.com/taiki-e/upload-rust-binary-action).

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything